### PR TITLE
Various fixes

### DIFF
--- a/event.go
+++ b/event.go
@@ -429,7 +429,7 @@ func (p *propertyParser) parseSimpleType(i int) (string, error) {
 retryLoop:
 	for {
 		r0, _, _ := tdhFormatProperty.Call(
-			uintptr(unsafe.Pointer(p.record)),
+			uintptr(unsafe.Pointer(p.info)),
 			uintptr(mapInfo),
 			p.ptrSize,
 			inType,

--- a/event.go
+++ b/event.go
@@ -400,9 +400,14 @@ var (
 // parseSimpleType wraps TdhFormatProperty to get rendered to string value of
 // @i-th event property.
 func (p *propertyParser) parseSimpleType(i int) (string, error) {
-	mapInfo, err := getMapInfo(p.record, p.info, i)
-	if err != nil {
-		return "", fmt.Errorf("failed to get map info; %w", err)
+	mapNameOffset := C.GetMapNameOffset(p.info, C.int(i))
+	var mapInfo unsafe.Pointer
+	if mapNameOffset != 0 {
+		info, err := getMapInfo(p.record, p.info, i)
+		if err != nil {
+			return "", fmt.Errorf("failed to get map info; %w", err)
+		}
+		mapInfo = info
 	}
 
 	var propertyLength C.uint
@@ -504,8 +509,12 @@ func (p *propertyParser) getOpcodeName() string {
 // If that mapping exists, function extracts it and returns a pointer to the buffer with
 // extracted info. If no mapping defined, function can legitimately return `nil, nil`.
 func getMapInfo(event C.PEVENT_RECORD, info C.PTRACE_EVENT_INFO, i int) (unsafe.Pointer, error) {
-	mapName := C.GetMapName(info, C.int(i))
+	offset := C.GetMapNameOffset(info, C.int(i))
+	if offset == 0 {
+		return nil, nil
+	}
 
+	mapName := C.GetMapName(info, C.int(i))
 	// Query map info if any exists.
 	var mapSize C.ulong
 	ret := C.TdhGetEventMapInformation(event, mapName, nil, &mapSize)

--- a/session.c
+++ b/session.c
@@ -113,6 +113,10 @@ LPWSTR GetMapName(PTRACE_EVENT_INFO info, int i) {
     return (LPWSTR)((PBYTE)(info) + info->EventPropertyInfoArray[i].nonStructType.MapNameOffset);
 }
 
+ULONG GetMapNameOffset(PTRACE_EVENT_INFO info, int i) {
+    return info->EventPropertyInfoArray[i].nonStructType.MapNameOffset;
+}
+
 BOOL PropertyIsStruct(PTRACE_EVENT_INFO info, int i) {
     return (info->EventPropertyInfoArray[i].Flags & PropertyStruct) == PropertyStruct;
 }

--- a/session.h
+++ b/session.h
@@ -29,6 +29,7 @@ ULONGLONG GetPropertyName(PTRACE_EVENT_INFO info, int idx);
 USHORT GetInType(PTRACE_EVENT_INFO info, int idx);
 USHORT GetOutType(PTRACE_EVENT_INFO info, int idx);
 LPWSTR GetMapName(PTRACE_EVENT_INFO info, int idx);
+ULONG GetMapNameOffset(PTRACE_EVENT_INFO info, int idx);
 int GetStructStartIndex(PTRACE_EVENT_INFO info, int idx);
 int GetStructLastIndex(PTRACE_EVENT_INFO info, int idx);
 BOOL PropertyIsStruct(PTRACE_EVENT_INFO info, int idx);


### PR DESCRIPTION
- The MapNameOffset field should only be used if it would result in a valid memory address, see official example:
https://learn.microsoft.com/en-us/windows/win32/etw/using-tdhformatproperty-to-consume-event-data
- For some very specific provider's very specific records the tdhFormatProperty call failed, this was because the call site supplied the wrong first argument
